### PR TITLE
Use native `Exception` in `ApiError`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,10 @@
         {
             "name": "Marc MOREAU",
             "email": "moreau.marc.web@gmail.com"
+        },
+        {
+            "name": "Roger Thomas",
+            "email": "rogere84@gmail.com"
         }
     ],
     "autoload": {

--- a/src/Functional/Error/ApiError.php
+++ b/src/Functional/Error/ApiError.php
@@ -9,7 +9,7 @@
 namespace MockingMagician\CoinbaseProSdk\Functional\Error;
 
 use MockingMagician\CoinbaseProSdk\Contracts\Error\ApiErrorInterface;
-use PHPUnit\Framework\Exception;
+use Exception;
 
 class ApiError extends Exception implements ApiErrorInterface
 {


### PR DESCRIPTION
**Little description of PR**

The use of `PHPUnit\Framework\Exception` in the `ApiError` causes the request to fail if you've run `composer install --no-dev -o`

**Requirements**

- [x] My code is tested and tests are part of this PR
- [x] Code style is respected
- [x] My author name is added to composer.json file (optional but preferred)

**Describe more the PR if needed**

For example in the case of an order that you've cancelled inside the Coinbase app and you try to retrieve it using this SDK it'll throw an ApiError which will cause a fatal error if you've installed dependencies using `--no-dev` as the PHPUnit dependency is not installed.

Error: 
```
PHP Fatal error:  Uncaught Error: Class 'PHPUnit\Framework\Exception' not found in /path/to/code/vendor/mocking-magician/coinbase-pro-sdk/src/Functional/Error/ApiError.php:14
```
